### PR TITLE
Fix variable set but not used error in OpenSimDecorationGenerator

### DIFF
--- a/libopensimcreator/Graphics/OpenSimDecorationGenerator.cpp
+++ b/libopensimcreator/Graphics/OpenSimDecorationGenerator.cpp
@@ -1418,7 +1418,7 @@ void osc::GenerateSubcomponentDecorations(
             GenerateBodySpatialVectorArrowDecorationsForForcesThatOnlyHaveComputeForceMethod(rendererState, *hcf);
             HandleHuntCrossleyForce(rendererState, *hcf);
         }
-        else if (const auto* const geom = dynamic_cast<const OpenSim::Geometry*>(&c)) {
+        else if (dynamic_cast<const OpenSim::Geometry*>(&c)) {
             // EDGE-CASE:
             //
             // if the component being rendered is geometry that was explicitly added into the model then


### PR DESCRIPTION
My compiler complains about this:
```sh
~/AlexDev/opensim-creator/libopensimcreator/Graphics/OpenSimDecorationGenerator.cpp:1421:36: error: variable 'geom' set but not used [-Werror,-Wunused-but-set-variable]
 1421 |         else if (const auto* const geom = dynamic_cast<const OpenSim::Geometry*>(&c)) {
      |                                    ^
1 error generated.
```

Compiler info:
```sh
clang version 20.1.6
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```